### PR TITLE
Prevent hasher function from hashing `undefined`.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -566,7 +566,10 @@ class LedgerNodeWorkSession {
   }
 }
 
-api.consensus._hasher = function(data, callback) {
+api.consensus._hasher = (data, callback) => {
+  if(!data) {
+    throw new TypeError('The `data` parameter must be a JSON-LD document.');
+  }
   async.auto({
     // canonize ledger event to nquads
     canonize: callback => jsonld.canonize(data, {


### PR DESCRIPTION
We *could* do more sophisticated checking on `data` but we do want this function to be as fast as possible.