### PR TITLE
Pass `ledgerNodeId` into the storage API.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -175,8 +175,16 @@ api.add = (actor, options, callback) => {
     ));
   }
 
+  const storage = {plugin: 'mongodb', services: []};
   // set defaults
-  options.storage = options.storage || 'mongodb';
+  if(options.storage) {
+    if(typeof options.storage === 'string') {
+      storage.plugin = options.storage;
+    }
+    if(_.isPlainObject(options.storage)) {
+      _.assign(storage, options.storage);
+    }
+  }
 
   const node = {
     id: 'urn:uuid:' + uuid(),
@@ -184,7 +192,7 @@ api.add = (actor, options, callback) => {
     owner: options.owner || null,
     peerLedgerAgent: options.peerLedgerAgents || [],
     storage: {
-      plugin: options.storage,
+      plugin: storage.plugin,
       id: null
     }
   };
@@ -218,9 +226,11 @@ api.add = (actor, options, callback) => {
         }, callback);
     },
     getStorage: ['checkPermission', (results, callback) =>
-      api.use(options.storage, callback)],
+      api.use(storage.plugin, callback)],
     initStorage: ['getStorage', (results, callback) =>
-      results.getStorage.api.add({}, {ledgerId: node.ledger}, callback)],
+      results.getStorage.api.add({}, {
+        ledgerId: node.ledger, ledgerNodeId: node.id, services: storage.services
+      }, callback)],
     insert: ['initStorage', (results, callback) => {
       record.ledgerNode.storage.id = results.initStorage.id;
       database.collections.ledgerNode.insert(


### PR DESCRIPTION
This is support of the storage layer being able to emit events pertaining to a particular ledger node.