### PR TITLE
Update variable names.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -175,7 +175,7 @@ api.add = (actor, options, callback) => {
     ));
   }
 
-  const storage = {plugin: 'mongodb', services: []};
+  const storage = {plugin: 'mongodb', storagePlugins: []};
   // set defaults
   if(options.storage) {
     if(typeof options.storage === 'string') {
@@ -229,7 +229,8 @@ api.add = (actor, options, callback) => {
       _use(storage.plugin, callback)],
     initStorage: ['getStorage', (results, callback) =>
       results.getStorage.api.add({}, {
-        ledgerId: node.ledger, ledgerNodeId: node.id, services: storage.services
+        ledgerId: node.ledger, ledgerNodeId: node.id,
+        plugins: storage.storagePlugins
       }, callback)],
     insert: ['initStorage', (results, callback) => {
       record.ledgerNode.storage.id = results.initStorage.id;


### PR DESCRIPTION
@dlongley I think you made a comment somewhere about what you thought were good names here, but I lost track of it.

The term `plugin` associated with `mongodb` has been in use since early on.

This is relevant when a node is added like this.  The `storage` options provided to the ledgerAgent API are passed on to the ledgerNode API.
```
      const options = {
        ledgerConfiguration: results.sign,
        genesis: true,
        public: true,
        owner: results.ledgerOwner.identity.id,
        // NOTE: these services correspond to plugins registered in index.js
        services: ['custom-agent'],
        storage: {
          plugin: 'mongodb',
          storagePlugins: ['custom-storage'],
        }
      };
      brLedgerAgent.add(results.ledgerOwner.identity, null, options, callback);
```