### PR TITLE
Use bedrock-jobs@3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-ledger ChangeLog
 
+## 8.0.0 - TBD
+
+### Changed
+- Use bedrock-jobs@3 which is not backwardly compatible.
+
 ## 7.2.0 - 2019-02-13
 
 ### Added

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,7 +4,6 @@
 const bedrock = require('bedrock');
 const {config} = bedrock;
 const path = require('path');
-require('bedrock-jobs');
 require('bedrock-ledger-context');
 require('bedrock-permission');
 require('bedrock-validation');
@@ -27,9 +26,6 @@ permissions.LEDGER_NODE_REMOVE = {
   comment: 'Required to remove a Ledger Node.'
 };
 
-// reducing idleTime to make consensus workers more responsive
-config.scheduler.idleTime = 1000;
-
 config.ledger = {};
 
 // jobs
@@ -48,18 +44,6 @@ config.ledger.jobs.scheduleConsensusWork = {
   // per CPU core (or per bedrock-ledger-node instance)
   workSessionConcurrencyPerInstance: 5
 };
-bedrock.util.config.main.pushComputed('scheduler.jobs', () => ({
-  id: 'ledger-node.jobs.scheduleConsensusWork',
-  type: 'ledger-node.jobs.scheduleConsensusWork',
-  // repeat forever, run every second
-  schedule: 'R/PT1S',
-  // no special priority
-  priority: 0,
-  concurrency: 1,
-  // use a 10000ms grace period between TTL for workers to finish up
-  // before forcibly running another worker
-  lockDuration: config.ledger.jobs.scheduleConsensusWork.ttl + 10000
-}));
 
 // common validation schemas
 config.validation.schema.paths.push(

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -5,16 +5,15 @@ const bedrock = require('bedrock');
 const {config} = require('bedrock');
 const database = require('bedrock-mongodb');
 const logger = require('./logger');
-const scheduler = require('bedrock-jobs');
-const {callbackify} = bedrock.util;
 const LedgerNodeWorkSession = require('./LedgerNodeWorkSession');
+const brJobs = require('bedrock-jobs');
 
 const {get: getLedgerNode} = require('./rootApi');
 
 // jobs
 const namespace = 'ledger-node';
-const JOB_SCHEDULE_CONSENSUS_WORK =
-  `${namespace}.jobs.scheduleConsensusWork`;
+const JOB_SCHEDULE_CONSENSUS_WORK = `${namespace}.jobs.scheduleConsensusWork`;
+let consensusQueue;
 
 // in memory (per process instance) concurrent work session tracking var
 let runningConsensusWorkSessions = 0;
@@ -23,12 +22,25 @@ let runningConsensusWorkSessions = 0;
 const api = {};
 module.exports = api;
 
-bedrock.events.on('bedrock.init', () => {
+bedrock.events.on('bedrock.init', async () => {
   if(config.ledger.jobs.scheduleConsensusWork.enabled) {
-    scheduler.define(JOB_SCHEDULE_CONSENSUS_WORK, api._scheduleConsensusWork);
+    consensusQueue = brJobs.addQueue({name: JOB_SCHEDULE_CONSENSUS_WORK});
+    // setup a processor for the queue with the default concurrency of 1
+    consensusQueue.process(api._scheduleConsensusWork);
+    await consensusQueue.add({}, {
+      // prevent duplicate jobs by specifying a non-unique jobId
+      jobId: JOB_SCHEDULE_CONSENSUS_WORK,
+      // repeated jobs are completed and rescheduled on every iteration
+      repeat: {
+        every: 1000
+      },
+      // do not keep record of successfully completed jobs in redis
+      removeOnComplete: true
+    });
   }
 });
 
+api._consensusQueue = consensusQueue;
 api._hasher = require('./hasher');
 api._rdfCanonizeAndHash = require('./rdfCanonizeAndHash');
 
@@ -40,9 +52,9 @@ api._rdfCanonizeAndHash = require('./rdfCanonizeAndHash');
  *
  * @return a Promise that resolves once the operation completes.
  */
-api._scheduleConsensusWork = callbackify(async job => {
-  logger.verbose(
-    `Running worker (${job.worker.id}) to schedule consensus work...`);
+api._scheduleConsensusWork = async j => {
+  const {opts: {jobId}} = j;
+  logger.verbose(`Running worker (${jobId}) to schedule consensus work...`);
 
   const start = Date.now();
   const {ttl} = config.ledger.jobs.scheduleConsensusWork;
@@ -74,16 +86,14 @@ api._scheduleConsensusWork = callbackify(async job => {
       offer(ledgerNode);
     } catch(e) {
       logger.error(
-        `Error while scheduling consensus work on worker (${job.worker.id})`,
+        `Error while scheduling consensus work on worker (${jobId})`,
         {error: e});
       break;
     }
   }
 
   // clear any node claimed by the scheduler
-  const query = {
-    'meta.workSession.id': job.worker.id
-  };
+  const query = {'meta.workSession.id': jobId};
   const update = {
     $set: {
       'meta.workSession': null,
@@ -94,11 +104,9 @@ api._scheduleConsensusWork = callbackify(async job => {
     await collection.update(query, update, singleUpdateOptions);
   } catch(e) {
     logger.error(
-      `Error after scheduling consensus work on worker (${job.worker.id})`,
-      {error: e});
+      `Error after scheduling consensus work on worker (${jobId})`, {error: e});
   } finally {
-    logger.verbose(
-      `Schedule consensus work worker (${job.worker.id}) finished.`);
+    logger.verbose(`Schedule consensus work worker (${jobId}) finished.`);
   }
 
   async function claimLedgerNode() {
@@ -119,7 +127,7 @@ api._scheduleConsensusWork = callbackify(async job => {
     };
     const update = {
       $set: {
-        'meta.workSession': {id: job.worker.id, expires: thisWorkerExpires},
+        'meta.workSession': {id: jobId, expires: thisWorkerExpires},
         'meta.updated': Date.now()
       }
     };
@@ -162,7 +170,7 @@ api._scheduleConsensusWork = callbackify(async job => {
     // schedule offering to reserve ledger node for a work session
     process.nextTick(() => {
       const session = new LedgerNodeWorkSession({
-        schedulerId: job.worker.id,
+        schedulerId: jobId,
         ledgerNode,
         onFinish() {
           runningConsensusWorkSessions--;
@@ -174,4 +182,4 @@ api._scheduleConsensusWork = callbackify(async job => {
       }
     });
   }
-});
+};

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -10,10 +10,7 @@ const brJobs = require('bedrock-jobs');
 
 const {get: getLedgerNode} = require('./rootApi');
 
-// jobs
 const namespace = 'ledger-node';
-const JOB_SCHEDULE_CONSENSUS_WORK = `${namespace}.jobs.scheduleConsensusWork`;
-let consensusQueue;
 
 // in memory (per process instance) concurrent work session tracking var
 let runningConsensusWorkSessions = 0;
@@ -24,12 +21,12 @@ module.exports = api;
 
 bedrock.events.on('bedrock.init', async () => {
   if(config.ledger.jobs.scheduleConsensusWork.enabled) {
-    consensusQueue = brJobs.addQueue({name: JOB_SCHEDULE_CONSENSUS_WORK});
+    const consensusQueue = api._jobQueue = brJobs.addQueue({name: namespace});
     // setup a processor for the queue with the default concurrency of 1
     consensusQueue.process(api._scheduleConsensusWork);
     await consensusQueue.add({}, {
       // prevent duplicate jobs by specifying a non-unique jobId
-      jobId: JOB_SCHEDULE_CONSENSUS_WORK,
+      jobId: 'scheduleConsensusWork',
       // repeated jobs are completed and rescheduled on every iteration
       repeat: {
         every: 1000
@@ -40,7 +37,6 @@ bedrock.events.on('bedrock.init', async () => {
   }
 });
 
-api._consensusQueue = consensusQueue;
 api._hasher = require('./hasher');
 api._rdfCanonizeAndHash = require('./rdfCanonizeAndHash');
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "peerDependencies": {
     "bedrock": "^1.12.0",
     "bedrock-injector": "^1.0.0",
+    "bedrock-jobs": "^3.0.0",
     "bedrock-ledger-context": "^11.0.0",
     "bedrock-mongodb": "^5.0.0",
     "bedrock-permission": "^2.5.1",

--- a/test/package.json
+++ b/test/package.json
@@ -30,7 +30,7 @@
     "bedrock-did-client": "digitalbazaar/bedrock-did-client#testnet_v2",
     "bedrock-identity": "^6.0.0",
     "bedrock-injector": "^1.0.0",
-    "bedrock-jobs": "digitalbazaar/bedrock-jobs#3.x",
+    "bedrock-jobs": "^3.0.0",
     "bedrock-ledger-consensus-uni": "^2.0.0",
     "bedrock-ledger-context": "^11.0.0",
     "bedrock-ledger-node": "file:..",

--- a/test/package.json
+++ b/test/package.json
@@ -30,7 +30,7 @@
     "bedrock-did-client": "digitalbazaar/bedrock-did-client#testnet_v2",
     "bedrock-identity": "^6.0.0",
     "bedrock-injector": "^1.0.0",
-    "bedrock-jobs": "^2.0.3",
+    "bedrock-jobs": "digitalbazaar/bedrock-jobs#3.x",
     "bedrock-ledger-consensus-uni": "^2.0.0",
     "bedrock-ledger-context": "^11.0.0",
     "bedrock-ledger-node": "file:..",


### PR DESCRIPTION
This is just a conversation starter related to how we want to work with a task scheduler.

In my view, we would more or less use the bull API as demonstrated here.

All that is needed in our bedrock-XXX module is a wrapper that allows us to specify any custom redis settings in the bedrock config.  I'm inclined to leave bedrock-jobs alone and create a new module for this `bull` wrapper.  Here's the bull github: https://github.com/OptimalBits/bull

we have `bedrock-redis`, so maybe `bedrock-bull` is the appropriate name for this?

Unfortunately, bedrock-redis and bedrock-bull use different redis clients, so there are no interesting reuse opportunities there.  For some reason bull is using the `ioredis` module instead of `redis` .