### PR TITLE
Move scheduleConsensusWork from bedrock.init to bedrock.ready.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # bedrock-ledger ChangeLog
 
+## 8.0.2 - TBD
+
+### Fixed
+- Move scheduling of consensus work from `bedrock.init` event to
+  `bedrock.ready`. Since bedrock-jobs@3 does not depend on `bedrock-mongodb`
+  consensus work was being scheduled before Mongo collections were initialized.
+
 ## 8.0.1 - 2019-03-25
 
 ### Fixed

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -19,7 +19,7 @@ let runningConsensusWorkSessions = 0;
 const api = {};
 module.exports = api;
 
-bedrock.events.on('bedrock.init', async () => {
+bedrock.events.on('bedrock.ready', async () => {
   if(config.ledger.jobs.scheduleConsensusWork.enabled) {
     const consensusQueue = api._jobQueue = brJobs.addQueue({name: namespace});
     // setup a processor for the queue with the default concurrency of 1


### PR DESCRIPTION
Fixes the following startup error we've been seeing in all the ledger projects:
```
2019-08-02T12:53:19.007Z - error: Error while scheduling consensus work on worker (repeat:bdfab489d015b8cfee86e97fd316216d:1564750399000) error=TypeError: Cannot read property 'find' of unde
fined
    at getLruLedgerNode (/home/node/app/node_modules/bedrock-ledger-node/lib/consensus.js:150:39)
    at claimLedgerNode (/home/node/app/node_modules/bedrock-ledger-node/lib/consensus.js:109:32)
    at Queue.api._scheduleConsensusWork (/home/node/app/node_modules/bedrock-ledger-node/lib/consensus.js:69:34)
    at handlers.(anonymous function) (/home/node/app/node_modules/bull/lib/queue.js:687:42)
    at Queue.processJob (/home/node/app/node_modules/bull/lib/queue.js:1054:22)
    at process._tickCallback (internal/process/next_tick.js:68:7), workerPid=17, details={
  "error": {}
}, module=bedrock-ledger-node
```