### PR TITLE
Use lru-memoize@2.

### DIFF
--- a/lib/rootApi.js
+++ b/lib/rootApi.js
@@ -13,9 +13,9 @@ const injector = require('./injector');
 const {validate} = require('bedrock-validation');
 const validator = require('./validator');
 const LedgerNode = require('./LedgerNode');
-const {default: {LruMemoize}} = require('@digitalbazaar/lru-memoize');
+const {LruCache} = require('@digitalbazaar/lru-memoize');
 
-const lruMemoize = new LruMemoize({
+const lruCache = new LruCache({
   max: 1000,
   maxAge: 1000 * 60 * 5
 });
@@ -245,7 +245,7 @@ api.get = async (actor, ledgerNodeId, options = {}) => {
   let result;
   // only use cache if no actor because actor permissions may have changed
   if(!actor) {
-    result = await lruMemoize.memoize({key: ledgerNodeId, fn});
+    result = await lruCache.memoize({key: ledgerNodeId, fn});
   } else {
     result = await fn();
   }
@@ -310,7 +310,7 @@ api.remove = async (actor, ledgerNodeId, options = {}) => {
 
   // delete cache entry even if the update operation fails, the cache will be
   // repopulated, this avoids cache/database sync issues and race conditions
-  lruMemoize.delete(ledgerNodeId);
+  lruCache.delete(ledgerNodeId);
 
   await database.collections.ledgerNode.updateOne({
     id: database.hash(ledgerNodeId)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-ledger-node",
   "dependencies": {
-    "@digitalbazaar/lru-memoize": "^1.1.0",
+    "@digitalbazaar/lru-memoize": "^2.0.0",
     "bnid": "^2.0.0",
     "fast-json-patch": "^2.0.6",
     "jsonld": "^2.0.1",


### PR DESCRIPTION
This is all the time I can give to this right now.  If it seems like a good idea to use the `updateAgeOnGet` flag, please track that with an issue or perhaps someone else can extend this PR.

https://github.com/digitalbazaar/lru-memoize/blob/main/lib/LruCache.js#L15

If this flag is wanted, then I believe it is also important to ensure that any failed requests to the `ledgerNode.get` API evacuate the cache.  This is the part that someone will need to spend time thinking about and testing.

