### PR TITLE
Upgrade to 2020 cryptosuites.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # bedrock-ledger ChangeLog
 
-## 12.1.0 - TBD
+## 13.0.0 - 2021-xx-xx
+
+### Changed
+- **BREAKING**: Upgrade to 2020 cryptosuites.
+- Update to latest lru-memoize@2.
 
 ### Added
 - Add `getNodeRecord` API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# bedrock-ledger ChangeLog
+# bedrock-ledger-node ChangeLog
 
 ## 13.0.0 - 2021-xx-xx
 

--- a/lib/rootApi.js
+++ b/lib/rootApi.js
@@ -128,6 +128,7 @@ api.add = async (actor, options) => {
       injector,
     }
   });
+
   if(!configResult.valid) {
     throw configResult.error;
   }

--- a/package.json
+++ b/package.json
@@ -34,10 +34,12 @@
     "bedrock": "2.0.0 - 4.x",
     "bedrock-injector": "^1.0.0",
     "bedrock-jsonld-document-loader": "^1.0.0",
-    "bedrock-ledger-context": "^15.0.0",
+    "bedrock-ledger-context": "^18.1.0",
     "bedrock-mongodb": "^8.1.0",
     "bedrock-permission": "^3.0.0",
-    "bedrock-validation": "^4.1.0"
+    "bedrock-validation": "^5.1.0",
+    "ed25519-signature-2020-context": "^1.1.0",
+    "x25519-key-agreement-2020-context": "^1.0.0"
   },
   "engines": {
     "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "bedrock-mongodb": "^8.1.0",
     "bedrock-permission": "^3.0.0",
     "bedrock-validation": "^5.1.0",
-    "ed25519-signature-2020-context": "^1.1.0",
+    "ed25519-signature-2020-context": "^1.1.0"
   },
   "engines": {
     "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "bedrock-permission": "^3.0.0",
     "bedrock-validation": "^5.1.0",
     "ed25519-signature-2020-context": "^1.1.0",
-    "x25519-key-agreement-2020-context": "^1.0.0"
   },
   "engines": {
     "node": ">=12"

--- a/schemas/webledger-validator.js
+++ b/schemas/webledger-validator.js
@@ -44,7 +44,7 @@ const createOperation = {
         id: schemas.url()
       }
     },
-    proof: schemas.linkedDataSignature2018()
+    proof: schemas.linkedDataSignature2020()
   },
   additionalProperties: false
 };
@@ -106,7 +106,7 @@ const updateOperation = {
       enum: ['UpdateWebLedgerRecord'],
     },
     recordPatch,
-    proof: schemas.linkedDataSignature2018(),
+    proof: schemas.linkedDataSignature2020(),
   },
 };
 
@@ -125,7 +125,10 @@ const ledgerConfiguration = {
   ],
   type: 'object',
   properties: {
-    '@context': schemas.jsonldContext(constants.WEB_LEDGER_CONTEXT_V1_URL),
+    '@context': schemas.jsonldContext([
+      constants.WEB_LEDGER_CONTEXT_V1_URL,
+      constants.ED25519_2020_CONTEXT_V1_URL
+    ]),
     consensusMethod: {
       type: 'string',
     },
@@ -235,7 +238,7 @@ const ledgerConfiguration = {
         }
       }
     },
-    proof: schemas.linkedDataSignature2018(),
+    proof: schemas.linkedDataSignature2020(),
     sequence: {
       type: 'integer',
       minimum: 0,

--- a/test/mocha/10-ledger-api.js
+++ b/test/mocha/10-ledger-api.js
@@ -23,7 +23,7 @@ describe('Ledger API', () => {
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
       verificationMethod:
-        'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+        'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
       key
     });
   });

--- a/test/mocha/10-ledger-api.js
+++ b/test/mocha/10-ledger-api.js
@@ -18,8 +18,9 @@ describe('Ledger API', () => {
     await helpers.prepareDatabase(mockData);
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
-      creator: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
-      privateKeyPem: mockData.groups.authorized.privateKey,
+      verificationMethod:
+        'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+      key: mockData.groups.authorized.key,
     });
   });
   describe('create API', () => {

--- a/test/mocha/10-ledger-api.js
+++ b/test/mocha/10-ledger-api.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+const {Ed25519VerificationKey2020} =
+  require('@digitalbazaar/ed25519-verification-key-2020');
 const brAccount = require('bedrock-account');
 const brLedgerNode = require('bedrock-ledger-node');
 const database = require('bedrock-mongodb');
@@ -16,11 +18,13 @@ let signedConfig;
 describe('Ledger API', () => {
   before(async function() {
     await helpers.prepareDatabase(mockData);
+    const key =
+      await Ed25519VerificationKey2020.from(mockData.keys.authorized);
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
       verificationMethod:
         'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
-      key: mockData.groups.authorized.key,
+      key
     });
   });
   describe('create API', () => {

--- a/test/mocha/25-peers-api.js
+++ b/test/mocha/25-peers-api.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+const {Ed25519VerificationKey2020} =
+  require('@digitalbazaar/ed25519-verification-key-2020');
 const bedrock = require('bedrock');
 const brAccount = require('bedrock-account');
 const brLedgerNode = require('bedrock-ledger-node');
@@ -18,10 +20,13 @@ const COLLECTION_NAME = 'ledgerNode_peer';
 describe('Peers API', () => {
   before(async function() {
     await helpers.prepareDatabase(mockData);
+    const key =
+      await Ed25519VerificationKey2020.from(mockData.keys.authorized);
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
-      creator: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
-      privateKeyPem: mockData.groups.authorized.privateKey,
+      verificationMethod:
+        'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+      key
     });
   });
   beforeEach(async function() {

--- a/test/mocha/25-peers-api.js
+++ b/test/mocha/25-peers-api.js
@@ -25,7 +25,7 @@ describe('Peers API', () => {
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
       verificationMethod:
-        'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+        'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
       key
     });
   });

--- a/test/mocha/30-blocks-api.js
+++ b/test/mocha/30-blocks-api.js
@@ -20,7 +20,7 @@ describe('Blocks API', () => {
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
       verificationMethod:
-        'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+        'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
       key
     });
   });

--- a/test/mocha/30-blocks-api.js
+++ b/test/mocha/30-blocks-api.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+const {Ed25519VerificationKey2020} =
+  require('@digitalbazaar/ed25519-verification-key-2020');
 const brAccount = require('bedrock-account');
 const brLedgerNode = require('bedrock-ledger-node');
 const helpers = require('./helpers');
@@ -13,10 +15,13 @@ let signedConfig;
 describe('Blocks API', () => {
   before(async function() {
     await helpers.prepareDatabase(mockData);
+    const key =
+      await Ed25519VerificationKey2020.from(mockData.keys.authorized);
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
-      creator: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
-      privateKeyPem: mockData.groups.authorized.privateKey,
+      verificationMethod:
+        'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+      key
     });
   });
   beforeEach(async function() {

--- a/test/mocha/35-operations-api.js
+++ b/test/mocha/35-operations-api.js
@@ -21,7 +21,7 @@ describe('Operations API', () => {
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
       verificationMethod:
-        'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+        'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
       key
     });
   });
@@ -55,7 +55,7 @@ describe('Operations API', () => {
         const operation = await helpers.signDocument({
           doc: testOperation,
           verificationMethod:
-            'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+            'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
           key
         });
 
@@ -77,7 +77,7 @@ describe('Operations API', () => {
         const operation = await helpers.signDocument({
           doc: testOperation,
           verificationMethod:
-            'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+            'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
           key
         });
         await ledgerNode.operations.add({operation});
@@ -98,7 +98,7 @@ describe('Operations API', () => {
         const operation = await helpers.signDocument({
           doc: testOperation,
           verificationMethod:
-            'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+            'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
           key
         });
         let err;
@@ -129,7 +129,7 @@ describe('Operations API', () => {
           const operation = await helpers.signDocument({
             doc: testOperation,
             verificationMethod:
-              'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+              'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
             key
           });
           let err;
@@ -158,7 +158,7 @@ describe('Operations API', () => {
         const operation = await helpers.signDocument({
           doc: testOperation,
           verificationMethod:
-            'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+            'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
           key
         });
         await ledgerNode.operations.add({operation});
@@ -198,7 +198,7 @@ describe('Operations API', () => {
         const operation = await helpers.signDocument({
           doc: testOperation,
           verificationMethod:
-            'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+            'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
           key
         });
 

--- a/test/mocha/35-operations-api.js
+++ b/test/mocha/35-operations-api.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+const {Ed25519VerificationKey2020} =
+  require('@digitalbazaar/ed25519-verification-key-2020');
 const brAccount = require('bedrock-account');
 const brLedgerNode = require('bedrock-ledger-node');
 const helpers = require('./helpers');
@@ -14,10 +16,13 @@ let signedConfig;
 describe('Operations API', () => {
   before(async function() {
     await helpers.prepareDatabase(mockData);
+    const key =
+      await Ed25519VerificationKey2020.from(mockData.keys.authorized);
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
-      creator: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
-      privateKeyPem: mockData.groups.authorized.privateKey,
+      verificationMethod:
+        'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+      key
     });
   });
   beforeEach(async function() {
@@ -45,11 +50,15 @@ describe('Operations API', () => {
             value: uuid()
           }
         };
+        const key =
+          await Ed25519VerificationKey2020.from(mockData.keys.authorized);
         const operation = await helpers.signDocument({
           doc: testOperation,
-          privateKeyPem: mockData.groups.authorized.privateKey,
-          creator: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144'
+          verificationMethod:
+            'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+          key
         });
+
         await ledgerNode.operations.add({operation});
       });
       it('should add operation without optional creator', async function() {
@@ -63,10 +72,13 @@ describe('Operations API', () => {
             value: uuid()
           }
         };
+        const key =
+          await Ed25519VerificationKey2020.from(mockData.keys.authorized);
         const operation = await helpers.signDocument({
           doc: testOperation,
-          privateKeyPem: mockData.groups.authorized.privateKey,
-          creator: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144'
+          verificationMethod:
+            'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+          key
         });
         await ledgerNode.operations.add({operation});
       });
@@ -81,10 +93,13 @@ describe('Operations API', () => {
             value: uuid()
           }
         };
+        const key =
+          await Ed25519VerificationKey2020.from(mockData.keys.authorized);
         const operation = await helpers.signDocument({
           doc: testOperation,
-          privateKeyPem: mockData.groups.authorized.privateKey,
-          creator: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144'
+          verificationMethod:
+            'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+          key
         });
         let err;
         try {
@@ -94,7 +109,8 @@ describe('Operations API', () => {
         }
         err.name.should.equal('SyntaxError');
         err.message.should.equal(
-          'Operation context must be "https://w3id.org/webledger/v1"');
+          'Operation context must contain "https://w3id.org/webledger/v1" ' +
+          'as the first element.');
       });
       it('should fail to add operation w/ incorrect context order',
         async () => {
@@ -108,10 +124,13 @@ describe('Operations API', () => {
               value: uuid()
             }
           };
+          const key =
+            await Ed25519VerificationKey2020.from(mockData.keys.authorized);
           const operation = await helpers.signDocument({
             doc: testOperation,
-            privateKeyPem: mockData.groups.authorized.privateKey,
-            creator: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144'
+            verificationMethod:
+              'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+            key
           });
           let err;
           try {
@@ -134,10 +153,13 @@ describe('Operations API', () => {
             value: uuid()
           }
         };
+        const key =
+          await Ed25519VerificationKey2020.from(mockData.keys.authorized);
         const operation = await helpers.signDocument({
           doc: testOperation,
-          privateKeyPem: mockData.groups.authorized.privateKey,
-          creator: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144'
+          verificationMethod:
+            'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+          key
         });
         await ledgerNode.operations.add({operation});
         // unilateral consensus allows immediate retrieval of an event with
@@ -171,10 +193,13 @@ describe('Operations API', () => {
             value: uuid()
           }
         };
+        const key =
+          await Ed25519VerificationKey2020.from(mockData.keys.authorized);
         const operation = await helpers.signDocument({
           doc: testOperation,
-          privateKeyPem: mockData.groups.authorized.privateKey,
-          creator: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144'
+          verificationMethod:
+            'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+          key
         });
 
         await ledgerNode.operations.add({operation});

--- a/test/mocha/40-events-api.js
+++ b/test/mocha/40-events-api.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+const {Ed25519VerificationKey2020} =
+  require('@digitalbazaar/ed25519-verification-key-2020');
 const bedrock = require('bedrock');
 const brAccount = require('bedrock-account');
 const brLedgerNode = require('bedrock-ledger-node');
@@ -16,10 +18,13 @@ let signedConfig;
 describe('Events API', () => {
   before(async function() {
     await helpers.prepareDatabase(mockData);
+    const key =
+      await Ed25519VerificationKey2020.from(mockData.keys.authorized);
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
-      creator: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
-      privateKeyPem: mockData.groups.authorized.privateKey,
+      verificationMethod:
+        'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+      key
     });
   });
   beforeEach(async function() {
@@ -45,10 +50,13 @@ describe('Events API', () => {
           value: uuid()
         }
       };
+      const key =
+        await Ed25519VerificationKey2020.from(mockData.keys.authorized);
       const operation = await helpers.signDocument({
         doc: testOperation,
-        privateKeyPem: mockData.groups.authorized.privateKey,
-        creator: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144'
+        verificationMethod:
+          'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+        key
       });
       const operationHash = await hasher(operation);
       await ledgerNode.operations.add({operation});

--- a/test/mocha/40-events-api.js
+++ b/test/mocha/40-events-api.js
@@ -23,7 +23,7 @@ describe('Events API', () => {
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
       verificationMethod:
-        'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+        'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
       key
     });
   });
@@ -55,7 +55,7 @@ describe('Events API', () => {
       const operation = await helpers.signDocument({
         doc: testOperation,
         verificationMethod:
-          'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+          'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
         key
       });
       const operationHash = await hasher(operation);

--- a/test/mocha/50-records-api.js
+++ b/test/mocha/50-records-api.js
@@ -25,7 +25,7 @@ describe('Records API', () => {
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
       verificationMethod:
-        'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+        'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
       key
     });
   });

--- a/test/mocha/50-records-api.js
+++ b/test/mocha/50-records-api.js
@@ -20,8 +20,8 @@ let signedConfig;
 describe('Records API', () => {
   before(async function() {
     await helpers.prepareDatabase(mockData);
-    const key =
-      await Ed25519VerificationKey2020.from(mockData.keys.authorized);
+    const key = await Ed25519VerificationKey2020.from(
+      mockData.keys.authorized);
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
       verificationMethod:

--- a/test/mocha/50-records-api.js
+++ b/test/mocha/50-records-api.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+const {Ed25519VerificationKey2020} =
+  require('@digitalbazaar/ed25519-verification-key-2020');
 const bedrock = require('bedrock');
 const brAccount = require('bedrock-account');
 const brLedgerNode = require('bedrock-ledger-node');
@@ -18,10 +20,13 @@ let signedConfig;
 describe('Records API', () => {
   before(async function() {
     await helpers.prepareDatabase(mockData);
+    const key =
+      await Ed25519VerificationKey2020.from(mockData.keys.authorized);
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
-      creator: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
-      privateKeyPem: mockData.groups.authorized.privateKey,
+      verificationMethod:
+        'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+      key
     });
   });
   beforeEach(async function() {

--- a/test/mocha/60-performance.js
+++ b/test/mocha/60-performance.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+const {Ed25519VerificationKey2020} =
+  require('@digitalbazaar/ed25519-verification-key-2020');
 const brLedgerNode = require('bedrock-ledger-node');
 const helpers = require('./helpers');
 const mockData = require('./mock.data');
@@ -19,10 +21,13 @@ describe.skip('Performance tests', () => {
   let storage;
   before(async function() {
     await helpers.prepareDatabase(mockData);
+    const key =
+      await Ed25519VerificationKey2020.from(mockData.keys.authorized);
     const ledgerConfiguration = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
-      creator: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
-      privateKeyPem: mockData.groups.authorized.privateKey,
+      verificationMethod:
+        'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+      key
     });
     ledgerNode = await brLedgerNode.add(null, {ledgerConfiguration});
     storage = ledgerNode.storage;

--- a/test/mocha/60-performance.js
+++ b/test/mocha/60-performance.js
@@ -26,7 +26,7 @@ describe.skip('Performance tests', () => {
     const ledgerConfiguration = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
       verificationMethod:
-        'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
+        'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
       key
     });
     ledgerNode = await brLedgerNode.add(null, {ledgerConfiguration});

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -11,7 +11,7 @@ const database = require('bedrock-mongodb');
 const jsigs = require('jsonld-signatures');
 const {promisify} = require('util');
 const {util: {uuid}} = bedrock;
-const {Ed25519Signature2020} = jsigs.suites;
+const {Ed25519Signature2020} = require('@digitalbazaar/ed25519-signature-2020');
 const {documentLoader} = require('bedrock-jsonld-document-loader');
 const {CapabilityInvocation} = require('@digitalbazaar/zcapld');
 
@@ -175,7 +175,10 @@ api.signDocument = async ({doc, verificationMethod, key}) => {
   return jsigs.sign(doc, {
     documentLoader,
     // FIXME: is this the right purpose?
-    purpose: new CapabilityInvocation(),
+    purpose: new CapabilityInvocation({
+      capability: doc.id || doc.ledger || doc.record.id,
+      capabilityAction: 'create'
+    }),
     suite: new Ed25519Signature2020({
       verificationMethod,
       key

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -11,12 +11,9 @@ const database = require('bedrock-mongodb');
 const jsigs = require('jsonld-signatures');
 const {promisify} = require('util');
 const {util: {uuid}} = bedrock;
-const {
-  purposes: {AssertionProofPurpose},
-  suites: {RsaSignature2018},
-  RSAKeyPair
-} = jsigs;
+const {Ed25519Signature2020} = jsigs.suites;
 const {documentLoader} = require('bedrock-jsonld-document-loader');
+const {CapabilityInvocation} = require('@digitalbazaar/zcapld');
 
 const api = {};
 module.exports = api;
@@ -174,14 +171,14 @@ async function insertTestData(mockData) {
   }
 }
 
-api.signDocument = async ({creator, doc, privateKeyPem}) => {
+api.signDocument = async ({doc, verificationMethod, key}) => {
   return jsigs.sign(doc, {
     documentLoader,
     // FIXME: is this the right purpose?
-    purpose: new AssertionProofPurpose(),
-    suite: new RsaSignature2018({
-      creator,
-      key: new RSAKeyPair({privateKeyPem})
+    purpose: new CapabilityInvocation(),
+    suite: new Ed25519Signature2020({
+      verificationMethod,
+      key
     }),
   });
 };

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -36,7 +36,7 @@ accounts[userName].meta = {
 const ledgerConfiguration = mock.ledgerConfiguration = {
   '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
   type: 'WebLedgerConfiguration',
-  ledger: 'did:v1:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59',
+  ledger: 'did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59',
   consensusMethod: 'UnilateralConsensus2017',
   ledgerConfigurationValidator: [{
     type: 'SignatureValidator2017',
@@ -45,8 +45,8 @@ const ledgerConfiguration = mock.ledgerConfiguration = {
       validatorFilterByType: ['WebLedgerConfiguration']
     }],
     approvedSigner: [
-      'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144'
-      // 'https://example.com/i/alpha'
+      'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144'
+      // 'https://good.example/i/alpha'
     ],
     minimumSignaturesRequired: 1
   }],
@@ -57,8 +57,8 @@ const ledgerConfiguration = mock.ledgerConfiguration = {
       validatorFilterByType: ['CreateWebLedgerRecord']
     }],
     approvedSigner: [
-      'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144'
-      // 'https://example.com/i/alpha'
+      'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144'
+      // 'https://good.example/i/alpha'
     ],
     minimumSignaturesRequired: 1
   }],
@@ -73,7 +73,7 @@ operations.alpha = {
   type: 'CreateWebLedgerRecord',
   record: {
     '@context': constants.TEST_CONTEXT_V1_URL,
-    id: `https://example.com/events/a05bebf8-c966-427f-92f2-ff9060f4bd23`,
+    id: `https://good.example/events/a05bebf8-c966-427f-92f2-ff9060f4bd23`,
     type: 'Concert',
     name: 'Primary Event',
     startDate: '2017-07-14T21:30',
@@ -100,7 +100,7 @@ operations.beta = {
   type: 'CreateWebLedgerRecord',
   record: {
     '@context': 'https://schema.org/',
-    id: 'https://example.com/events/1234567',
+    id: 'https://good.example/events/1234567',
     type: 'Concert',
     name: 'Big Band Concert in New York City',
     startDate: '2017-07-14T21:30',
@@ -117,7 +117,7 @@ operations.gamma = {
   '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
   type: 'UpdateWebLedgerRecord',
   recordPatch: {
-    target: `https://example.com/events/a05bebf8-c966-427f-92f2-ff9060f4bd23`,
+    target: `https://good.example/events/a05bebf8-c966-427f-92f2-ff9060f4bd23`,
     sequence: 0,
     patch: [{
       op: 'add', path: '/endDate', value: '2017-07-14T23:30'
@@ -128,7 +128,7 @@ operations.delta = {
   '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
   type: 'UpdateWebLedgerRecord',
   recordPatch: {
-    target: `https://example.com/events/a05bebf8-c966-427f-92f2-ff9060f4bd23`,
+    target: `https://good.example/events/a05bebf8-c966-427f-92f2-ff9060f4bd23`,
     sequence: 0,
     patch: [{
       op: 'replace', path: '/name',
@@ -175,128 +175,69 @@ blocks.event = {
   operation: [{
     type: 'CreateWebLedgerRecord',
     record: {
-      id: 'https://example.com/events/123456',
+      id: 'https://good.example/events/123456',
       description: 'Example event'
     }
   }]
 };
 
 // constants
-mock.authorizedSignerUrl = 'https://example.com/keys/authorized-key-1';
+mock.authorizedSignerUrl = 'https://good.example/keys/authorized-key-1';
 
-// all mock keys for all groups
-mock.groups = {
+// all mock keys
+mock.keys = {
   authorized: {
-    publicKey: '-----BEGIN PUBLIC KEY-----\n' +
-      'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAskcRISeoOvgQM8KxMEzP\n' +
-      'DMSfcw9NKJRvXNoFnxS0j7DcTPvi0zMXKAY5smANZ1iz9jQ43X/EUDNyjaWkiDUr\n' +
-      'lpxGxTFq9D+hUnfzPCW6xAprzZaYhvuHun88CmULWeyWLphISk3/3YhRGnywyUfK\n' +
-      'AuYYnKo6F+lDPNyPhknlB2uLblE4upqY5OrvlBdey6PV8teyjVSFo+WSTqzH02ne\n' +
-      'X0aaIzZ675BWZyBGK5wCq/6vgCOSBqePflPXY2CfwdMVRe4I3FRnqEsKVQtZ2zwi\n' +
-      '5j8YSZKNH4+2SrwuGqG/XcZaKCgKNMNDLRErZkdSPGCLM+OoPUOJEKdCvV3zUZYC\n' +
-      'mwIDAQAB\n' +
-      '-----END PUBLIC KEY-----',
-    privateKey: '-----BEGIN RSA PRIVATE KEY-----\n' +
-      'MIIEpQIBAAKCAQEAskcRISeoOvgQM8KxMEzPDMSfcw9NKJRvXNoFnxS0j7DcTPvi\n' +
-      '0zMXKAY5smANZ1iz9jQ43X/EUDNyjaWkiDUrlpxGxTFq9D+hUnfzPCW6xAprzZaY\n' +
-      'hvuHun88CmULWeyWLphISk3/3YhRGnywyUfKAuYYnKo6F+lDPNyPhknlB2uLblE4\n' +
-      'upqY5OrvlBdey6PV8teyjVSFo+WSTqzH02neX0aaIzZ675BWZyBGK5wCq/6vgCOS\n' +
-      'BqePflPXY2CfwdMVRe4I3FRnqEsKVQtZ2zwi5j8YSZKNH4+2SrwuGqG/XcZaKCgK\n' +
-      'NMNDLRErZkdSPGCLM+OoPUOJEKdCvV3zUZYCmwIDAQABAoIBAQCMdIMhXO4kr2WM\n' +
-      'chpJVGpXw91fuDFxBCkMvVRqddSf1JZsLJMTFBBtXyI7z4Mf5fm6wn/+une/PBlH\n' +
-      'UbZj/Yf+29bB62I5VpxRreE7hPo1E4TFb51x01+m5jE2e09LJKNZyG5D5FnufkRv\n' +
-      'msdpfR7B0+iWHWMxjXyEybxl73f6tEZcsfK/O46rtVsD/e8szyugg6zrrYWX8BA4\n' +
-      'sIRHzLvOZIow5eNbkAFfxXbIRLxjxFt2zSFM3a0GjKkU/7Jb8XoNszHc0eFVS79y\n' +
-      'PwQDeoqUP7sHLoHqazhFxI1KJftA/9NE6Nw+U/XJvQRyEaJxAGYgXvvRXhVtEN/H\n' +
-      '0y4/tbJZAoGBANvph6zmm49ExBXIg5K6JZw/9vM5GdJpmOTglQuLZGYJ9zwcAiqq\n' +
-      'U0mVGsJW0uq5VrHyqknc+edBfYD9K76mf0Sn9jG6rLL1fCl8BnLaF21tGVHU2W+Y\n' +
-      'ogcYXRkgYgYVl6RhvRqEsMWSEdr0S0z240bOsUB5W1mA601q7PwXfWYPAoGBAM+I\n' +
-      'eXxuskg+pCrWjgPke2Rk7PeEXrWPilSMR1ueA5kNCNdAMmxbDqDD7TKmKsyIfEEQ\n' +
-      '3VcWLGVY4vj0yW+ptsw+QFlt8PSjCT2z1heJW9AFEA/9ULU0ZpVdgy+ys9/cXSfq\n' +
-      'hZC4UQVwL3ODZE+hIU8pEJw1wTEMUvUBlxkOb4a1AoGBAI/6ydWt9lNK1obcjShX\n' +
-      'r6ApUOnVjM5yTKQtVegFD2qvQ6ubOt/sPDOE58wtRFJhnh1Ln6pUf1mlSyJUn3tn\n' +
-      'TxQIU+wjKEbS6sPOa/puR8BhGZ62GNYzvIGgtfNpfEQ3ht0dEM536bSw+fe80kBF\n' +
-      'tG/7i5mG2wQyn9xEEXzLdFKJAoGAQA7rGNp+U0hqmgJyAYeUAtAYSOpl5XryAtjt\n' +
-      '6byjdamNUguxxLpykHMJkzmxOkLiv566A3iHqZy/KoM8bigfkXmhmTkTSB/O6WnK\n' +
-      'KqeuXE5Dv/u73sLW60HbDW0GkpHNe1Wrdpk+AQS40Nn8q4ub4XhWdTEuebpJHPEp\n' +
-      't4U6LYUCgYEAvi38SUMij1zrNMVoslx5VojF961KCY+RNJvv9HmwV/W2XwjF0VGX\n' +
-      'luDSMT5bBXHf1kQfB+DJGo2M6it2IOEZQjd9AJdW1baLGwm56AyQNko7HtEczH0n\n' +
-      '42EADs/ajTEckTxULdirbEk2rINRwQC5kWMde3fcwAnn6xt3wvOyuwg=\n' +
-      '-----END RSA PRIVATE KEY-----'
+    id: mock.authorizedSignerUrl,
+    type: 'Ed25519VerificationKey2020',
+    controller: 'https://good.example/i/alpha',
+    publicKeyMultibase: 'z6MkpNdMFtT36D2qZLDN7MF3Fw7bbyA5xjqCekrB1qAnbzp1',
+    privateKeyMultibase: 'zrv3xnTZB6cPZyuE61YxwYbC4yacW864MtbdgeLJS7rwg3Uc' +
+      '7bsJ2swmYhYBfkNyrNQY5vsygRmnt2hvaf1LnBbXDbw'
   },
-  unauthorized: { // unauthorized group
-    publicKey: '-----BEGIN PUBLIC KEY-----\n' +
-      'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlretzNDRSy2Dmr8xywmP\n' +
-      '5BCE8LnFhfl7QB+7gsZSVANeoASk7l++JXM0nv/PJMuq9R8arekQ2tEGA53w1TU8\n' +
-      'AbgaK1KYHngIU1X6EK9shPEjuy0pZu+63opkkaCD3euCCraogEk8Vhtx6VbCi04g\n' +
-      'SGErFpWW6HRO5S3skw8p8+5iV4hZSR2QT/IW65yjBN22MGvOnLCEUEA+MMsbREdL\n' +
-      'PwHtSFanDKseejdzTrBguHh6G4BBSswuB/isWYuKM/9/yHB+mNKwuksEcfT4uJjj\n' +
-      'aN5LeRfeGrf6mSQ0KT/y/yIExtrLat9apG5EJbSw86++WXyjhR+Bl4wQNcCNYRHC\n' +
-      'HwIDAQAB\n' +
-      '-----END PUBLIC KEY-----',
-    privateKey: '-----BEGIN RSA PRIVATE KEY-----\n' +
-      'MIIEpAIBAAKCAQEAlretzNDRSy2Dmr8xywmP5BCE8LnFhfl7QB+7gsZSVANeoASk\n' +
-      '7l++JXM0nv/PJMuq9R8arekQ2tEGA53w1TU8AbgaK1KYHngIU1X6EK9shPEjuy0p\n' +
-      'Zu+63opkkaCD3euCCraogEk8Vhtx6VbCi04gSGErFpWW6HRO5S3skw8p8+5iV4hZ\n' +
-      'SR2QT/IW65yjBN22MGvOnLCEUEA+MMsbREdLPwHtSFanDKseejdzTrBguHh6G4BB\n' +
-      'SswuB/isWYuKM/9/yHB+mNKwuksEcfT4uJjjaN5LeRfeGrf6mSQ0KT/y/yIExtrL\n' +
-      'at9apG5EJbSw86++WXyjhR+Bl4wQNcCNYRHCHwIDAQABAoIBAQCL53byz8foFBi8\n' +
-      '9cvf4EFsgBUXbCq5oYtSS+KAk13q1LHqskTzbXaRRu7KxUTgsBpCrZvTYayeojcF\n' +
-      '9n+POno4UlAgdOv2JI/946pcAKsogLsdTd/HyLLbTvXp5Glj//BXx5SEePcEKzfD\n' +
-      'VSEDtQLsjR41Oai6oPR3cvjOzd2wquAT3+/KsPjhOR/dcBF0+vf7zsr+HjUhWyJB\n' +
-      '6aEjAXLQzXnbqrJIQvx5Md9dm8vf8k+/QQ9uMCWbzAZHwzkEbPOQyYvQuN2EDFr0\n' +
-      'jVgRUF/HUth/iweAm46iiHukPEAwfF9Qhryr9Fyoch9Y9XFYyfRtHAGI3SBR85C1\n' +
-      'u0kY6QaZAoGBAOVuctsE0Qa3ZGP7GKGwYJLYTPy5o0YqQt3ynsfe5/MZXRzjcpC7\n' +
-      'sCntTXQimU9iVyNHHvZ9hxgO4pYsBc81e5ciSbios1N/DjmHjj0/N6vZbl4+5+Ws\n' +
-      'hzHkqCKJNkfx0gd/O11//6aPXIMbCj7lUnvUSyxWRARY0MAlfpDTacvlAoGBAKgr\n' +
-      'vG4b9x1iOhRSMtoz7/Xly6oUIUfcz0lFR/bh4jEdpsFiGUG8WEADe/2IgxM5BrUW\n' +
-      'uLvUmROEBLPfijaHXf1WUJll9Y0suFWKFKvzrqZj8Z8Fso5d4CBSUlt9vf8K634F\n' +
-      '3vVRl/CopO7xfVZrpwkRGBI23vxDGrl5qqSOjl2zAoGBANcFrXUgzXn69IZTdSFM\n' +
-      'OSZGu9h7bs86mlKCqVbuzPnjwoVpkRyeGpsgwN9f8ckZhEsWw6kFuk/M24UcmxE4\n' +
-      'sazSQL9ktDRDtqQqLB+wmM9hRvPjBtkU2dvjzcQYTpwcwdeu4Ydeh82lPHHPLMoH\n' +
-      'iEdvjkhuTO66AmKigTzgNp4VAoGALDSK7HqnY27ti2fr/BWI7x8/gO6XrPcq+byf\n' +
-      'ZRMNTRHZQp4Ru4jRvcnsrsFSixwDWlilqKICtvGN9uY8w4ajuzMULq5xdHGb5shM\n' +
-      'FMMSVqSQ39c0j123y2c4RNpxtffd3RuX9u5CvTznVfPemXfkyWpX5HnN9YuCG90S\n' +
-      'cP0UCScCgYBXe5AL2398R+/1blgm2cycJvYEmvJb0MtS6ikOd0M5Nci/uOUBCt/1\n' +
-      'AIVgd0FgUA4zaQowuAhnMqennYYsvh+rUz7GNpcQQIhGWkmnPTsB6XU70zxnQ7yP\n' +
-      'VucJRhKAJ3S9G4KDkhxBO0S3guEQFiDaalh39m+UwUDPsdrmioqaoQ==\n' +
-      '-----END RSA PRIVATE KEY-----'
+  unauthorized: {
+    id: 'https://bad.example/keys/unauthorized-key-evil',
+    type: 'Ed25519VerificationKey2020',
+    controller: 'https://bad.example/i/omega',
+    publicKeyMultibase: 'z6Mkew1q8W3F8i3sgj1asCHZagjsNF5Y9ZRYHtCFJmvjq1o3',
+    privateKeyMultibase: 'zrv1cGnBy3PWkxii4xPSbmpR3bei1eZWTZ9qnBWW4NQE2YCS' +
+      'ZFc3ov2zTE23fpvaUhmqJjcXYvVqMdRja6kFKEsmHBB'
   }
 };
 
 mock.ldDocuments = {};
 
-mock.ldDocuments['https://example.com/i/alpha'] = {
+mock.ldDocuments['https://good.example/i/alpha'] = {
   '@context': constants.SECURITY_CONTEXT_V2_URL,
-  id: 'https://example.com/i/alpha',
+  id: 'https://good.example/i/alpha',
   publicKey: [{
     id: mock.authorizedSignerUrl,
-    type: 'RsaVerificationKey2018',
-    owner: 'https://example.com/i/alpha',
-    publicKeyPem: mock.groups.authorized.publicKey
+    type: 'Ed25519VerificationKey2020',
+    owner: 'https://good.example/i/alpha',
+    publicKeyPem: mock.keys.authorized.publicKeyMultibase
   }]
 };
 mock.ldDocuments[mock.authorizedSignerUrl] = {
   '@context': constants.SECURITY_CONTEXT_V2_URL,
-  type: 'RsaVerificationKey2018',
-  owner: 'https://example.com/i/alpha',
+  type: 'Ed25519VerificationKey2020',
+  owner: 'https://good.example/i/alpha',
   id: mock.authorizedSignerUrl,
-  publicKeyPem: mock.groups.authorized.publicKey
+  publicKeyPem: mock.keys.authorized.publicKeyMultibase
 };
-mock.ldDocuments['did:v1:53ebca61-5687-4558-b90a-03167e4c2838'] = {
+mock.ldDocuments['did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838'] = {
   '@context': constants.SECURITY_CONTEXT_V2_URL,
-  id: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838',
+  id: 'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838',
   assertionMethod: [{
-    id: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
-    type: 'RsaVerificationKey2018',
-    owner: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838',
-    publicKeyPem: mock.groups.authorized.publicKey
+    id: 'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
+    type: 'Ed25519VerificationKey2020',
+    owner: 'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838',
+    publicKeyPem: mock.keys.authorized.publicKeyMultibase
   }]
 };
-mock.ldDocuments['did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144'] = {
+mock.ldDocuments[
+  'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144'] = {
   '@context': constants.SECURITY_CONTEXT_V2_URL,
-  type: 'RsaVerificationKey2018',
-  controller: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838',
-  id: 'did:v1:53ebca61-5687-4558-b90a-03167e4c2838/keys/144',
-  publicKeyPem: mock.groups.authorized.publicKey
+  type: 'Ed25519VerificationKey2020',
+  controller: 'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838',
+  id: 'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
+  publicKeyPem: mock.keys.authorized.publicKeyMultibase
 };

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -84,15 +84,6 @@ operations.alpha = {
       priceCurrency: 'USD',
       url: `https://example.org/purchase/a05bebf8-c966-427f-92f2-ff9060f4bd23`,
     }
-  },
-  // using verbose signature for performance tests
-  proof: {
-    type: 'RsaSignature2018',
-    created: '2017-05-10T19:47:13Z',
-    // eslint-disable-next-line max-len
-    creator: 'https://bedrock.local:18443/consensus/continuity2017/voters/57565658-0d8a-4668-b734-e801aeaa6472#key',
-    // eslint-disable-next-line max-len
-    signatureValue: 'nlx8c9uFI8Ur/h57F5AeHHrKPSKiiGJmN6APRnYesQPK4LXftnm2lzqpWzsvKGDPzH6QfoOIktQu2Ax0pj/Bi6Oa4/Na75HuoRGppaHCqlyrgbr5EUPRCiYSjlsYKBhEN6ITdmR/O8iGz9WZi4PQjSW9XrrP8bQLeu9Kzsu5hdkzmgS4f3PCXpImwpKFttyF7xARvSQxrgRxZrqWPIGtD9sghRY2/Zn3T2npTaOTXMhgW9Lc7uEpjThnCEsrKflshbLGevZglc/njBp5SoEgon8CuzQIkMBFjCTEdJYBtTuk0AF5BcVyoxPDfH9bdUYOIMFaDhZBQKM5tQEU2GqE/g=='
   }
 };
 operations.beta = {
@@ -164,7 +155,7 @@ eventBlocks.alpha = {
 const blocks = mock.blocks = {};
 blocks.config = {
   '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
-  id: 'did:v1:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59/blocks/',
+  id: 'did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59/blocks/',
   type: 'WebLedgerEventBlock',
   event: [events.config]
 };
@@ -202,42 +193,4 @@ mock.keys = {
     privateKeyMultibase: 'zrv1cGnBy3PWkxii4xPSbmpR3bei1eZWTZ9qnBWW4NQE2YCS' +
       'ZFc3ov2zTE23fpvaUhmqJjcXYvVqMdRja6kFKEsmHBB'
   }
-};
-
-mock.ldDocuments = {};
-
-mock.ldDocuments['https://good.example/i/alpha'] = {
-  '@context': constants.SECURITY_CONTEXT_V2_URL,
-  id: 'https://good.example/i/alpha',
-  publicKey: [{
-    id: mock.authorizedSignerUrl,
-    type: 'Ed25519VerificationKey2020',
-    owner: 'https://good.example/i/alpha',
-    publicKeyPem: mock.keys.authorized.publicKeyMultibase
-  }]
-};
-mock.ldDocuments[mock.authorizedSignerUrl] = {
-  '@context': constants.SECURITY_CONTEXT_V2_URL,
-  type: 'Ed25519VerificationKey2020',
-  owner: 'https://good.example/i/alpha',
-  id: mock.authorizedSignerUrl,
-  publicKeyPem: mock.keys.authorized.publicKeyMultibase
-};
-mock.ldDocuments['did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838'] = {
-  '@context': constants.SECURITY_CONTEXT_V2_URL,
-  id: 'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838',
-  assertionMethod: [{
-    id: 'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
-    type: 'Ed25519VerificationKey2020',
-    owner: 'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838',
-    publicKeyPem: mock.keys.authorized.publicKeyMultibase
-  }]
-};
-mock.ldDocuments[
-  'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144'] = {
-  '@context': constants.SECURITY_CONTEXT_V2_URL,
-  type: 'Ed25519VerificationKey2020',
-  controller: 'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838',
-  id: 'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
-  publicKeyPem: mock.keys.authorized.publicKeyMultibase
 };

--- a/test/package.json
+++ b/test/package.json
@@ -50,6 +50,7 @@
     "ed25519-signature-2020-context": "^1.1.0",
     "grunt": "^1.0.1",
     "jsonld-signatures": "^9.0.0",
-    "nyc": "^15.1.0"
+    "nyc": "^15.1.0",
+    "x25519-key-agreement-2020-context": "^1.0.0"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -29,13 +29,14 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-ledger-node",
   "dependencies": {
+    "@digitalbazaar/zcapld": "^4.0.0",
     "bedrock": "^3.0.0",
     "bedrock-account": "^4.2.0",
     "bedrock-injector": "^1.0.0",
     "bedrock-jobs": "^3.0.0",
     "bedrock-jsonld-document-loader": "^1.0.0",
     "bedrock-ledger-consensus-uni": "^2.0.0",
-    "bedrock-ledger-context": "^15.0.0",
+    "bedrock-ledger-context": "^18.1.0",
     "bedrock-ledger-node": "file:..",
     "bedrock-ledger-storage-mongodb": "^5.0.0",
     "bedrock-ledger-validator-signature": "digitalbazaar/bedrock-ledger-validator-signature#bedrock-2",
@@ -43,10 +44,12 @@
     "bedrock-permission": "^3.0.0",
     "bedrock-security-context": "^3.0.0",
     "bedrock-test": "^5.3.0",
-    "bedrock-validation": "^4.1.0",
+    "bedrock-validation": "^5.1.0",
     "cross-env": "^7.0.2",
+    "ed25519-signature-2020-context": "^1.1.0",
     "grunt": "^1.0.1",
-    "jsonld-signatures": "^4.5.1",
-    "nyc": "^15.1.0"
+    "jsonld-signatures": "^9.0.0",
+    "nyc": "^15.1.0",
+    "x25519-key-agreement-2020-context": "^1.0.0"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -50,7 +50,6 @@
     "ed25519-signature-2020-context": "^1.1.0",
     "grunt": "^1.0.1",
     "jsonld-signatures": "^9.0.0",
-    "nyc": "^15.1.0",
-    "x25519-key-agreement-2020-context": "^1.0.0"
+    "nyc": "^15.1.0"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-ledger-node",
   "dependencies": {
+    "@digitalbazaar/ed25519-signature-2020": "^3.0.0",
     "@digitalbazaar/zcapld": "^4.0.0",
     "bedrock": "^3.0.0",
     "bedrock-account": "^4.2.0",
@@ -39,7 +40,7 @@
     "bedrock-ledger-context": "^18.1.0",
     "bedrock-ledger-node": "file:..",
     "bedrock-ledger-storage-mongodb": "^5.0.0",
-    "bedrock-ledger-validator-signature": "digitalbazaar/bedrock-ledger-validator-signature#bedrock-2",
+    "bedrock-ledger-validator-signature": "digitalbazaar/bedrock-ledger-validator-signature#disable-signature-check",
     "bedrock-mongodb": "^8.1.0",
     "bedrock-permission": "^3.0.0",
     "bedrock-security-context": "^3.0.0",


### PR DESCRIPTION
I'm going to make a major release for bedrock-ledger-node after this is merged... all the dependent libraries have stabilized at this point. The last branch-based dependency, `bedrock-ledger-validator-signature` is only used for testing `bedrock-ledger-node`.