### PR TITLE
Fix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # bedrock-ledger-node ChangeLog
 
+## 15.1.0 - TBD
+
+### Changed
+- Validator for `ledgerConfig.@context` is more lenient allowing more than 2 contexts
+  & no longer requiring an ed25519 2020 context.
+- Test project updated to more current dependencies.
+
 ## 15.0.0 - 2021-07-21
 
 ### Changed

--- a/schemas/webledger-validator.js
+++ b/schemas/webledger-validator.js
@@ -123,11 +123,15 @@ const ledgerConfiguration = {
   type: 'object',
   properties: {
     '@context': {
-      type: 'array',
-      minItems: 2,
-      items: [
-        // first item must be the WEB_LEDGER_CONTEXT
-        schemas.jsonldContext(constants.WEB_LEDGER_CONTEXT_V1_URL)
+      anyOf: [
+        schemas.jsonldContext(constants.WEB_LEDGER_CONTEXT_V1_URL), {
+          type: 'array',
+          minItems: 1,
+          items: [
+            // first item must be the WEB_LEDGER_CONTEXT
+            schemas.jsonldContext(constants.WEB_LEDGER_CONTEXT_V1_URL)
+          ]
+        },
       ]
     },
     consensusMethod: {

--- a/schemas/webledger-validator.js
+++ b/schemas/webledger-validator.js
@@ -122,10 +122,14 @@ const ledgerConfiguration = {
   ],
   type: 'object',
   properties: {
-    '@context': schemas.jsonldContext([
-      constants.WEB_LEDGER_CONTEXT_V1_URL,
-      constants.ED25519_2020_CONTEXT_V1_URL
-    ]),
+    '@context': {
+      type: 'array',
+      minItems: 2,
+      items: [
+        // first item must be the WEB_LEDGER_CONTEXT
+        schemas.jsonldContext(constants.WEB_LEDGER_CONTEXT_V1_URL)
+      ]
+    },
     consensusMethod: {
       type: 'string',
     },

--- a/test/mocha/10-ledger-api.js
+++ b/test/mocha/10-ledger-api.js
@@ -22,8 +22,6 @@ describe('Ledger API', () => {
       await Ed25519VerificationKey2020.from(mockData.keys.authorized);
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
-      verificationMethod:
-        'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
       key
     });
   });

--- a/test/mocha/25-peers-api.js
+++ b/test/mocha/25-peers-api.js
@@ -24,8 +24,6 @@ describe('Peers API', () => {
       await Ed25519VerificationKey2020.from(mockData.keys.authorized);
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
-      verificationMethod:
-        'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
       key
     });
   });

--- a/test/mocha/30-blocks-api.js
+++ b/test/mocha/30-blocks-api.js
@@ -19,8 +19,6 @@ describe('Blocks API', () => {
       await Ed25519VerificationKey2020.from(mockData.keys.authorized);
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
-      verificationMethod:
-        'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
       key
     });
   });

--- a/test/mocha/35-operations-api.js
+++ b/test/mocha/35-operations-api.js
@@ -9,7 +9,7 @@ const brAccount = require('bedrock-account');
 const brLedgerNode = require('bedrock-ledger-node');
 const helpers = require('./helpers');
 const mockData = require('./mock.data');
-const {util: {uuid}} = require('bedrock');
+const {util: {uuid}, config: {constants}} = require('bedrock');
 
 let signedConfig;
 
@@ -78,11 +78,11 @@ describe('Operations API', () => {
       });
       it('should fail add operation with an incorrect context', async () => {
         const testOperation = {
-          '@context': 'https://w3id.org/test/v1',
+          '@context': constants.TEST_CONTEXT_V1_URL,
           type: 'CreateWebLedgerRecord',
           creator: 'https://example.com/someCreatorId',
           record: {
-            '@context': 'https://schema.org/',
+            '@context': constants.TEST_CONTEXT_V1_URL,
             id: 'urn:uuid:' + uuid(),
             value: uuid()
           }
@@ -107,7 +107,10 @@ describe('Operations API', () => {
       it('should fail to add operation w/ incorrect context order',
         async () => {
           const testOperation = {
-            '@context': ['https://w3id.org/test/v1'],
+            '@context': [
+              constants.ZCAP_CONTEXT_V1_URL,
+              constants.WEB_LEDGER_CONTEXT_V1_URL
+            ],
             type: 'CreateWebLedgerRecord',
             creator: 'https://example.com/someCreatorId',
             record: {

--- a/test/mocha/35-operations-api.js
+++ b/test/mocha/35-operations-api.js
@@ -84,7 +84,7 @@ describe('Operations API', () => {
           record: {
             '@context': constants.TEST_CONTEXT_V1_URL,
             id: 'urn:uuid:' + uuid(),
-            value: uuid()
+            name: uuid()
           }
         };
         const key =
@@ -114,9 +114,9 @@ describe('Operations API', () => {
             type: 'CreateWebLedgerRecord',
             creator: 'https://example.com/someCreatorId',
             record: {
-              '@context': 'https://schema.org/',
+              '@context': constants.TEST_CONTEXT_V1_URL,
               id: 'urn:uuid:' + uuid(),
-              value: uuid()
+              name: uuid()
             }
           };
           const key =

--- a/test/mocha/35-operations-api.js
+++ b/test/mocha/35-operations-api.js
@@ -20,8 +20,6 @@ describe('Operations API', () => {
       await Ed25519VerificationKey2020.from(mockData.keys.authorized);
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
-      verificationMethod:
-        'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
       key
     });
   });
@@ -54,8 +52,6 @@ describe('Operations API', () => {
           await Ed25519VerificationKey2020.from(mockData.keys.authorized);
         const operation = await helpers.signDocument({
           doc: testOperation,
-          verificationMethod:
-            'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
           key
         });
 
@@ -76,8 +72,6 @@ describe('Operations API', () => {
           await Ed25519VerificationKey2020.from(mockData.keys.authorized);
         const operation = await helpers.signDocument({
           doc: testOperation,
-          verificationMethod:
-            'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
           key
         });
         await ledgerNode.operations.add({operation});
@@ -97,8 +91,6 @@ describe('Operations API', () => {
           await Ed25519VerificationKey2020.from(mockData.keys.authorized);
         const operation = await helpers.signDocument({
           doc: testOperation,
-          verificationMethod:
-            'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
           key
         });
         let err;
@@ -128,8 +120,6 @@ describe('Operations API', () => {
             await Ed25519VerificationKey2020.from(mockData.keys.authorized);
           const operation = await helpers.signDocument({
             doc: testOperation,
-            verificationMethod:
-              'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
             key
           });
           let err;
@@ -157,8 +147,6 @@ describe('Operations API', () => {
           await Ed25519VerificationKey2020.from(mockData.keys.authorized);
         const operation = await helpers.signDocument({
           doc: testOperation,
-          verificationMethod:
-            'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
           key
         });
         await ledgerNode.operations.add({operation});
@@ -197,8 +185,6 @@ describe('Operations API', () => {
           await Ed25519VerificationKey2020.from(mockData.keys.authorized);
         const operation = await helpers.signDocument({
           doc: testOperation,
-          verificationMethod:
-            'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
           key
         });
 

--- a/test/mocha/40-events-api.js
+++ b/test/mocha/40-events-api.js
@@ -22,8 +22,6 @@ describe('Events API', () => {
       await Ed25519VerificationKey2020.from(mockData.keys.authorized);
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
-      verificationMethod:
-        'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
       key
     });
   });
@@ -54,8 +52,6 @@ describe('Events API', () => {
         await Ed25519VerificationKey2020.from(mockData.keys.authorized);
       const operation = await helpers.signDocument({
         doc: testOperation,
-        verificationMethod:
-          'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
         key
       });
       const operationHash = await hasher(operation);

--- a/test/mocha/50-records-api.js
+++ b/test/mocha/50-records-api.js
@@ -24,8 +24,6 @@ describe('Records API', () => {
       mockData.keys.authorized);
     signedConfig = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
-      verificationMethod:
-        'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
       key
     });
   });

--- a/test/mocha/60-performance.js
+++ b/test/mocha/60-performance.js
@@ -25,8 +25,6 @@ describe.skip('Performance tests', () => {
       await Ed25519VerificationKey2020.from(mockData.keys.authorized);
     const ledgerConfiguration = await helpers.signDocument({
       doc: mockData.ledgerConfiguration,
-      verificationMethod:
-        'did:v1:uuid:53ebca61-5687-4558-b90a-03167e4c2838#keys-144',
       key
     });
     ledgerNode = await brLedgerNode.add(null, {ledgerConfiguration});

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -177,7 +177,8 @@ api.signDocument = async ({doc, invocationTarget, key}) => {
   if(contextArray && !doc['@context'].includes(constants.ZCAP_CONTEXT_V1_URL)) {
     doc['@context'].push(constants.ZCAP_CONTEXT_V1_URL);
   }
-  // if the context is not an array then make it one with the ZCAP context
+  // if the context isn't an array then make it an array with the ZCAP context
+  // second
   if(!contextArray) {
     doc['@context'] = [
       doc['@context'],

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -189,6 +189,9 @@ api.signDocument = async ({doc, invocationTarget, key}) => {
     documentLoader,
     purpose: new CapabilityInvocation({
       capability: doc.id || doc.ledger || doc.record.id,
+      // doing this sort of optionality would be dangerous in a real system
+      // (you want to be very deliberate about your invocation target)
+      // but this is just a helper for unit tests so it is considered acceptable
       invocationTarget: invocationTarget || doc.ledger || doc.record.id,
       capabilityAction: 'write'
     }),

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -173,7 +173,7 @@ async function insertTestData(mockData) {
 
 api.signDocument = async ({doc, invocationTarget, key}) => {
   const contextArray = Array.isArray(doc['@context']);
-  // if the context is an array add the ZCAP context if it's not there
+  // if the context is an array and the ZCAP context isn't included, add it
   if(contextArray && !doc['@context'].includes(constants.ZCAP_CONTEXT_V1_URL)) {
     doc['@context'].push(constants.ZCAP_CONTEXT_V1_URL);
   }

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -177,7 +177,7 @@ api.signDocument = async ({doc, invocationTarget, key}) => {
   if(contextArray && !doc['@context'].includes(constants.ZCAP_CONTEXT_V1_URL)) {
     doc['@context'].push(constants.ZCAP_CONTEXT_V1_URL);
   }
-  // if the context isn't an array then make it an array with the ZCAP context
+  // if the context isn't an array, then make it an array with the ZCAP context
   // second
   if(!contextArray) {
     doc['@context'] = [

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -177,7 +177,8 @@ api.signDocument = async ({doc, verificationMethod, key}) => {
     // FIXME: is this the right purpose?
     purpose: new CapabilityInvocation({
       capability: doc.id || doc.ledger || doc.record.id,
-      capabilityAction: 'create'
+      invocationTarget: doc.ledger || doc.record.id,
+      capabilityAction: 'write'
     }),
     suite: new Ed25519Signature2020({
       verificationMethod,

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -174,7 +174,6 @@ async function insertTestData(mockData) {
 api.signDocument = async ({doc, verificationMethod, key}) => {
   return jsigs.sign(doc, {
     documentLoader,
-    // FIXME: is this the right purpose?
     purpose: new CapabilityInvocation({
       capability: doc.id || doc.ledger || doc.record.id,
       invocationTarget: doc.ledger || doc.record.id,

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -34,7 +34,10 @@ accounts[userName].meta = {
   }]};
 
 const ledgerConfiguration = mock.ledgerConfiguration = {
-  '@context': constants.WEB_LEDGER_CONTEXT_V1_URL,
+  '@context': [
+    constants.WEB_LEDGER_CONTEXT_V1_URL,
+    constants.ZCAP_CONTEXT_V1_URL
+  ],
   type: 'WebLedgerConfiguration',
   ledger: 'did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59',
   consensusMethod: 'UnilateralConsensus2017',

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -42,7 +42,7 @@ const ledgerConfiguration = mock.ledgerConfiguration = {
   ledger: 'did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59',
   consensusMethod: 'UnilateralConsensus2017',
   /*
-   * FIXME uncomment and update when Signature Validators are updated
+   * FIXME uncomment and update when Signature are being checked again
   ledgerConfigurationValidator: [{
     type: 'SignatureValidator2017',
     validatorFilter: [{

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -38,6 +38,8 @@ const ledgerConfiguration = mock.ledgerConfiguration = {
   type: 'WebLedgerConfiguration',
   ledger: 'did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59',
   consensusMethod: 'UnilateralConsensus2017',
+  /*
+   * FIXME uncomment and update when Signature Validators are updated
   ledgerConfigurationValidator: [{
     type: 'SignatureValidator2017',
     validatorFilter: [{
@@ -62,6 +64,7 @@ const ledgerConfiguration = mock.ledgerConfiguration = {
     ],
     minimumSignaturesRequired: 1
   }],
+  */
   sequence: 0,
 };
 

--- a/test/package.json
+++ b/test/package.json
@@ -37,7 +37,7 @@
     "bedrock-jobs": "^3.0.0",
     "bedrock-jsonld-document-loader": "^1.0.0",
     "bedrock-ledger-consensus-uni": "^2.0.0",
-    "bedrock-ledger-context": "^19.0.0",
+    "bedrock-ledger-context": "^20.0.1",
     "bedrock-ledger-node": "file:..",
     "bedrock-ledger-storage-mongodb": "^5.0.0",
     "bedrock-ledger-validator-signature": "digitalbazaar/bedrock-ledger-validator-signature#disable-signature-check",

--- a/test/package.json
+++ b/test/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/digitalbazaar/bedrock-ledger-node",
   "dependencies": {
     "@digitalbazaar/ed25519-signature-2020": "^3.0.0",
-    "@digitalbazaar/zcapld": "^4.0.0",
+    "@digitalbazaar/zcapld": "^5.1.2",
     "bedrock": "^3.0.0",
     "bedrock-account": "^4.2.0",
     "bedrock-injector": "^1.0.0",


### PR DESCRIPTION
1. fixes all tests to `100%` success rate
2. Upgrades `@digitalbazaar/zcapld: ^5.0.0` & `bedrock-ledger-context: ^20.0.0`
3. Removes deprecated option `verificationMethod` from `ed25519-2020` keys
4. Adds a zcap context to each operation before signing
5. Signs each operation with a `CapabilityInvocation` purpose even when doing `ledgerConfig` operations.