### PR TITLE
Upgrade to jsonld ^5.0.2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ coverage
 node_modules
 npm-debug.log
 reports
-package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage
 node_modules
 npm-debug.log
 reports
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.py[co]
 *.sw[nop]
 *~
+*.log
 .cache
 .project
 .settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-ledger-node ChangeLog
 
+## 15.2.0 - TBD
+
+### Changed
+- Upgraded `jsonld` to `^5.2.0`.
+
 ## 15.1.0 - 2021-09-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # bedrock-ledger-node ChangeLog
 
-## 15.2.0 - TBD
+## 16.0.0 - TBD
 
 ### Changed
-- Upgraded `jsonld` to `^5.2.0`.
+- **BREAKING**: Upgraded `jsonld` to `^5.2.0` this might cause the `canonizedBytes`
+  & `hash` of records to change.
 
 ## 15.1.0 - 2021-09-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## 16.0.0 - TBD
 
 ### Changed
-- **BREAKING**: Upgraded `jsonld` to `^5.2.0` this might cause the `canonizedBytes`
-  & `hash` of records to change.
+- **BREAKING**: Upgraded `jsonld` to `^5.2.0`. Marked as a breaking major change to help avoid any unknown upgrading issues in live systems due to potential JSON-LD edge case processing changes. No issues are expected in normal use cases. If such an issue exists, it might cause the `canonizedBytes` and `hash` of records to change.
 
 ## 15.1.0 - 2021-09-24
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@digitalbazaar/lru-memoize": "^2.1.0",
     "bnid": "^2.0.0",
     "fast-json-patch": "^2.0.6",
-    "jsonld": "^2.0.1",
+    "jsonld": "^5.2.0",
     "lodash": "^4.17.10",
     "multibase": "^0.6.0",
     "multihashes": "^0.4.14",


### PR DESCRIPTION
Addresses: https://github.com/digitalbazaar/bedrock-ledger-node/issues/101

- [x] Look for deprecated or changed parameters with `jsonld.cannonize`
  - [x] algorithm 'URDNA2015'
  - [x] documentLoader
  - [x] format 'application/n-quads'
- [x] ensure test project actually hits the code paths that use `jsonld`
- [x] investigate CI node v14 failure


PR Concerns:

`jsonld: ^2.0.0` cannonize:

```js
 {
    "@context": "https://w3id.org/webledger/v1",
    "type": "WebLedgerConfigurationEvent",
    "ledgerConfiguration": {
      "@context": [
        "https://w3id.org/webledger/v1",
        "https://w3id.org/zcap/v1",
        "https://w3id.org/security/suites/ed25519-2020/v1"
      ],   
      "type": "WebLedgerConfiguration",
      "ledger": "did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59",
      "consensusMethod": "UnilateralConsensus2017",
      "sequence": 0,
      "proof": {
        "type": "Ed25519Signature2020",
        "created": "2021-10-22T16:06:41Z",
        "verificationMethod": "https://good.example/keys/authorized-key-1",
        "proofPurpose": "capabilityInvocation",
        "capability": "did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59",
        "invocationTarget": "did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59",
        "capabilityAction": "write",
        "proofValue": "z2UUEMNjkhVzpMKoqzbgeNYoSi2oe6fii7dT3ZQRBho64JGFnt6gbm9YtD8PG39wQPbdy88btMBre2hnXCctGm9Xq"
      }    
    }    
  },
  "canonized": "_:c14n1 <http://purl.org/dc/terms/created> \"2021-10-22T16:06:41Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:c14n0 .\n_:c14n1
<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519Signature2020> _:c14n0 .\n_:c14n1 <https://w3id.org/                
security#capability> <did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59> _:c14n0 .\n_:c14n1 <https://w3id.org/security#capabilityAction> \"write\" _:  
c14n0 .\n_:c14n1 <https://w3id.org/security#invocationTarget> <did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59> _:c14n0 .\n_:c14n1 <https://w3id.org/
security#proofPurpose> <https://w3id.org/security#capabilityInvocationMethod> _:c14n0 .\n_:c14n1 <https://w3id.org/security#proofValue>              
\"z2UUEMNjkhVzpMKoqzbgeNYoSi2oe6fii7dT3ZQRBho64JGFnt6gbm9YtD8PG39wQPbdy88btMBre2hnXCctGm9Xq\"^^<https://w3id.org/security#multibase> _:c14n0 .\n_:c14n1
<https://w3id.org/security#verificationMethod> <https://good.example/keys/authorized-key-1> _:c14n0 .\n_:c14n2 <http://www.w3.org/1999/02/22-rdf-syntax-
ns#type> <https://w3id.org/webledger#WebLedgerConfiguration> _:c14n4 .\n_:c14n2 <https://w3id.org/json-ld-patch#sequence> \"0\"^^<http://www.w3.org/
2001/XMLSchema#integer> _:c14n4 .\n_:c14n2 <https://w3id.org/security#proof> _:c14n0 _:c14n4 .\n_:c14n2 <https://w3id.org/webledger#ledger> <did:v1: 
uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59> _:c14n4 .\n_:c14n3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/                
webledger#WebLedgerConfigurationEvent> .\n_:c14n3 <https://w3id.org/webledger#ledgerConfiguration> _:c14n4 .\n"
}
```

`jsonld: ^5.0.1`

```js
    "@context": "https://w3id.org/webledger/v1",
    "type": "WebLedgerConfigurationEvent",
    "ledgerConfiguration": {
      "@context": [
        "https://w3id.org/webledger/v1",
        "https://w3id.org/zcap/v1",
        "https://w3id.org/security/suites/ed25519-2020/v1"
      ],   
      "type": "WebLedgerConfiguration",
      "ledger": "did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59",
      "consensusMethod": "UnilateralConsensus2017",
      "sequence": 0,
      "proof": {
        "type": "Ed25519Signature2020",
        "created": "2021-10-22T16:03:31Z",
        "verificationMethod": "https://good.example/keys/authorized-key-1",
        "proofPurpose": "capabilityInvocation",
        "capability": "did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59",
        "invocationTarget": "did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59",
        "capabilityAction": "write",
        "proofValue": "z31PNNwqwRnr9XGt8xAhHgyLSaSkzoYumXmGsFRmbyn3MHnkH36CovZAFbxhQfJ2ZeRUj8tyjmGfGUpkiSYjYCzNS"
      }    
    }    
  }
  "canonized": "_:c14n0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/webledger#WebLedgerConfiguration> _:c14n2 .\n_:c14n0        
<https://w3id.org/json-ld-patch#sequence> \"0\"^^<http://www.w3.org/2001/XMLSchema#integer> _:c14n2 .\n_:c14n0 <https://w3id.org/security#proof> _:     c14n3 _:c14n2 .\n_:c14n0 <https://w3id.org/webledger#ledger> <did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59> _:c14n2 .\n_:c14n1 <http://www.w3.org/  1999/02/22-rdf-syntax-ns#type> <https://w3id.org/webledger#WebLedgerConfigurationEvent> .\n_:c14n1 <https://w3id.org/webledger#ledgerConfiguration> _:
c14n2 .\n_:c14n4 <http://purl.org/dc/terms/created> \"2021-10-22T16:03:31Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> _:c14n3 .\n_:c14n4 <http://
www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/security#Ed25519Signature2020> _:c14n3 .\n_:c14n4 <https://w3id.org/security#capability>
<did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59> _:c14n3 .\n_:c14n4 <https://w3id.org/security#capabilityAction> \"write\" _:c14n3 .\n_:c14n4
<https://w3id.org/security#invocationTarget> <did:v1:uuid:eb8c22dc-bde6-4315-92e2-59bd3f3c7d59> _:c14n3 .\n_:c14n4 <https://w3id.org/
security#proofPurpose> <https://w3id.org/security#capabilityInvocationMethod> _:c14n3 .\n_:c14n4 <https://w3id.org/security#proofValue>
\"z31PNNwqwRnr9XGt8xAhHgyLSaSkzoYumXmGsFRmbyn3MHnkH36CovZAFbxhQfJ2ZeRUj8tyjmGfGUpkiSYjYCzNS\"^^<https://w3id.org/security#multibase> _:c14n3 .\n_:c14n4
<https://w3id.org/security#verificationMethod> <https://good.example/keys/authorized-key-1> _:c14n3 .\n"
```

`WebLedgerConfigurationEvent` cannonizations are not the same.
1. Is the `jsonld: ^5.0.0` cannonize in `n-quads` format?
2. Have the documentLoader or other docs changed?
3. We don't test for cannonizalization.


Code path affected by this upgrade:

https://github.com/digitalbazaar/bedrock-ledger-node/blob/4c4f0be9a28f5315eb30c50c147b3756cc30ba0b/lib/rdfCanonizeAndHash.js#L16-L27