### PR TITLE
Allow unique database name extension for testing.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,10 @@ jobs:
         cd test
         npm install
     - name: Run test with Node.js ${{ matrix.node-version }}
+      env:
+        # Used to create a unique database name extension.
+        # See test/test.config.js.
+        TEST_NODE_VERSION: ${{ matrix.node-version }}
       run: |
         cd test
         npm test

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -13,7 +13,13 @@ const roles = config.permission.roles;
 config.mocha.tests.push(path.join(__dirname, 'mocha'));
 
 // MongoDB
-config.mongodb.name = 'bedrock_ledger_node_test';
+// Add unique db name extension when running tests in parallel for multiple
+// node versions. See .github/workflows/main.yml.
+let nameExt = '';
+if(process.env.TEST_NODE_VERSION) {
+  nameExt = '_' + process.env.TEST_NODE_VERSION.replace('.', '_');
+}
+config.mongodb.name = 'bedrock_ledger_node_test' + nameExt;
 config.mongodb.dropCollections.onInit = true;
 config.mongodb.dropCollections.collections = [];
 


### PR DESCRIPTION
- This helps to avoid race conditions and conflicts if tests are run in
  parallel for multiple node versions with one database.